### PR TITLE
Transmit the DNS of the modem in the leases

### DIFF
--- a/dnsmasq/dnsmasq.conf
+++ b/dnsmasq/dnsmasq.conf
@@ -4,4 +4,5 @@ server=#DNS_SERVER#
 
 interface=eth0
 dhcp-option=3,#LAN_IP#
+dhcp-option=6,#DNS_SERVER#
 dhcp-range=#LAN_IFACE#,#LAN_RANGE_MIN#,#LAN_RANGE_MAX#,255.255.255.0,48h


### PR DESCRIPTION
The OTB will then use them directly and we can properly shut down all
dnsmasq instances on the modems